### PR TITLE
Fix ELISA well refs in frontend

### DIFF
--- a/frontend/src/elisa_well/utils.tsx
+++ b/frontend/src/elisa_well/utils.tsx
@@ -54,9 +54,11 @@ export function deserializeElisaWellRef(elisaWellRef: string): ElisaWellRef {
  * @returns The serialized elisa well reference URI string
  */
 export function serializeElisaWellRef(elisaWellRef: ElisaWellRef): string {
-  return `${elisaWellRef.project}
-  :${elisaWellRef.plate}
-  :${elisaWellRef.location}`;
+  return (
+    `${elisaWellRef.project}:` +
+    `${elisaWellRef.plate}:` +
+    `${elisaWellRef.location}`
+  );
 }
 
 /**


### PR DESCRIPTION
Whitespace was getting added

Partially addresses #19, where individual ELISA well objects could not be retrieved