### PR TITLE
fix: set antigen properly on ELISAs

### DIFF
--- a/backend/antigenapi/views_old.py
+++ b/backend/antigenapi/views_old.py
@@ -470,6 +470,8 @@ class ElisaPlateSerializer(ElisaPlateWithoutWellsSerializer):
             # than conditionally update
             ElisaWell.objects.filter(plate=plate).delete()
             self._create_wells(plate, antigen, well_set)
+        else:
+            ElisaWell.objects.filter(plate=plate).update(antigen=antigen)
         return instance
 
 

--- a/frontend/src/crudtemplates/AddEditObjectPage.js
+++ b/frontend/src/crudtemplates/AddEditObjectPage.js
@@ -60,6 +60,13 @@ const AddEditObjectPage = (props) => {
                 if (res.status === 404) {
                   setError(404);
                 } else {
+                  // Set antigen for elisa plates
+                  if (props.schema.viewUrl === "/elisas") {
+                    if (data["elisawell_set"].length) {
+                      data["antigen"] = data["elisawell_set"][0]["antigen"];
+                    }
+                  }
+                  // Set record data
                   setRecord(data);
                 }
                 setLoading(false);


### PR DESCRIPTION
The data model assumes antigens can differ per well, but the frontend currently maps this to a single antigen entry. This wasn't showing on the edit page, or persisting updates, which we fix here.