### PR TITLE
fix: antigen page where no ELISAs linked

### DIFF
--- a/backend/antigenapi/views_old.py
+++ b/backend/antigenapi/views_old.py
@@ -259,6 +259,10 @@ class AntigenSerializer(ModelSerializer):
                 .distinct()
             )
 
+            # Handle case where no ELISAs available
+            if not elisa_plate_ids:
+                return SequencingRunSerializer(many=True).data
+
             # Try PostgreSQL JSONField filtering
             # Build a Q object to check if any given elisa_plate is inside the JSONField
             query = Q()


### PR DESCRIPTION
This was showing all sequencing runs on the antigen page when no ELISAs were linked to the antigen. It should of course show no sequencing runs.