### PR TITLE
fix(imgt): add required moleculeType param to V-QUEST requests

### DIFF
--- a/backend/antigenapi/bioinformatics/imgt.py
+++ b/backend/antigenapi/bioinformatics/imgt.py
@@ -130,7 +130,7 @@ _VQUEST_BATCH_SIZE = 50  # V-QUEST limit per request
 _VQUEST_TIMEOUT = (10, 120)  # (connect timeout, read timeout) in seconds
 
 
-def run_vquest(fasta_data, species="alpaca", receptor="IG"):
+def run_vquest(fasta_data, species="alpaca", receptor="IG", molecule_type="Unknown"):
     """Submit FASTA sequences to the IMGT/V-QUEST web service and return results."""
     records = [r for r in re.split(r"\n(?=>)", fasta_data) if r.strip()]
     if not records:
@@ -146,6 +146,7 @@ def run_vquest(fasta_data, species="alpaca", receptor="IG"):
                 "inputType": "inline",
                 "species": species,
                 "receptorOrLocusType": receptor,
+                "moleculeType": molecule_type,
                 "sequences": "\n".join(records[i : i + _VQUEST_BATCH_SIZE]),
                 "resultType": "excel",
                 "xv_outputtype": 3,

--- a/backend/antigenapi/bioinformatics/test_imgt.py
+++ b/backend/antigenapi/bioinformatics/test_imgt.py
@@ -171,3 +171,25 @@ def test_timeout_passed_to_requests(mock_post):
 
     _, kwargs = mock_post.call_args
     assert "timeout" in kwargs, "timeout must be passed to requests.post"
+
+
+@patch("antigenapi.bioinformatics.imgt.requests.post")
+def test_molecule_type_default_sent(mock_post):
+    """moleculeType=Unknown is included in the POST data by default."""
+    mock_post.return_value = _mock_zip_response(_HEADER + _airr_row(0))
+
+    run_vquest(_fasta(1))
+
+    _, kwargs = mock_post.call_args
+    assert kwargs.get("data", {}).get("moleculeType") == "Unknown"
+
+
+@patch("antigenapi.bioinformatics.imgt.requests.post")
+def test_molecule_type_override(mock_post):
+    """molecule_type kwarg is forwarded to the POST data."""
+    mock_post.return_value = _mock_zip_response(_HEADER + _airr_row(0))
+
+    run_vquest(_fasta(1), molecule_type="cDNA")
+
+    _, kwargs = mock_post.call_args
+    assert kwargs.get("data", {}).get("moleculeType") == "cDNA"


### PR DESCRIPTION
IMGT added a new mandatory "Molecule Type" field (gDNA/cDNA/Unknown). Submitting without it returns the HTML form page instead of a ZIP, breaking all V-QUEST calls. Default to "Unknown" to match the form default and preserve existing behaviour.

Also adds two unit tests covering the default value and the override.