### PR TITLE
fix(imgt): surface IMGT errors as user-facing 400 instead of 500

### DIFF
--- a/backend/antigenapi/bioinformatics/imgt.py
+++ b/backend/antigenapi/bioinformatics/imgt.py
@@ -156,8 +156,14 @@ def run_vquest(fasta_data, species="alpaca", receptor="IG", molecule_type="Unkno
         response.raise_for_status()
         if "text/html" in response.headers.get("Content-Type", ""):
             tree = etree.fromstring(response.content, etree.HTMLParser())
-            errors = tree.xpath("//div[contains(@class,'form_error')]/text()")
-            raise ValueError("; ".join(errors) or "V-QUEST returned an HTML error")
+            errors = [
+                e.strip()
+                for e in tree.xpath("//div[contains(@class,'form_error')]/text()")
+                if e.strip()
+            ]
+            raise ValueError(
+                "; ".join(errors) or "IMGT/V-QUEST returned an unexpected HTML response"
+            )
         try:
             with zipfile.ZipFile(io.BytesIO(response.content)) as zf:
                 outputs.append({name: zf.read(name) for name in zf.namelist()})

--- a/backend/antigenapi/views/sequencing.py
+++ b/backend/antigenapi/views/sequencing.py
@@ -485,7 +485,10 @@ class SequencingRunViewSet(AuditLogMixin, DeleteProtectionMixin, ModelViewSet):
         # Convert to FASTA in-memory; run_vquest batches to 50 sequences per request
         fasta_file = as_fasta_files(seq_data, max_file_size=None)[0]
 
-        vquest_results = run_vquest(fasta_file)
+        try:
+            vquest_results = run_vquest(fasta_file)
+        except ValueError as e:
+            raise ValidationError({"file": f"IMGT/V-QUEST error: {e}"})
 
         parameters_file_data = vquest_results["Parameters.txt"]
         vquest_airr_data = vquest_results["vquest_airr.tsv"]


### PR DESCRIPTION
Strip whitespace-only text nodes from the V-QUEST HTML error XPath result before joining, fixing blank ValueError messages in Sentry.

Wrap run_vquest in sequencing.py to convert ValueError into a ValidationError so the frontend receives a 400 with a readable message rather than a generic 500.